### PR TITLE
Fixed bug in profile cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_usb_keyboard"
 plugin_name = "OctoPrint-Usb_keyboard"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.4"
+plugin_version = "0.2.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Due to complaints, investigated the sudden/inexplicable deletion of
profiles.  Found a glaring but that may have been responsible. Also
made the deletion less immediate. Now it should wait 5 days before
attempting to delete a potentially abandoned profile.