### PR TITLE
Fixing event devices limit

### DIFF
--- a/octoprint_usb_keyboard/usb_keyboard/listener/keyboard_listener_evdev.py
+++ b/octoprint_usb_keyboard/usb_keyboard/listener/keyboard_listener_evdev.py
@@ -66,7 +66,7 @@ class KeyboardListenerThread(threading.Thread):
     devices = [InputDevice(device) for device in list_devices()]
     for device in devices:
       message += f"  Device {device}\n"
-      options.append(str(device)[7:24].replace(",", ""))
+      options.append(device.path)
       message += f"    Info {device.info}\n"
       message += f"    Physical {device.phys}\n"
     return message, options


### PR DESCRIPTION
Currently event source symlink name (files in /dev/input)  is limited to 6 digits so if you have more than 10 sources you can't use them. Also if someone wants to have persistent pointer to some device he can create evdev rule, but he won't be able to use it because of that limitation 

PS. if someone is interested in creating persistent link to device this is my evdev rule
`
SUBSYSTEMS=="input", ATTRS{name}=="USB USB Keyboard", ENV{ID_MODEL_ID}=="0c23", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="input/eventPRIM"`

note that symlink must start with "event" prefix because python's evdev lib is using event* list filter