### PR TITLE
Adds information on why devices may not be listed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ or manually using this URL:
 ## Configuration
 
 None. Configure plugin settings through the settings dialog.
+
+### `input` group
+
+If you are not seeing any devices in the "device listener configuration" dialog,
+ensure that the user running octoprint is part of the `input` group. (See the
+[python-evdev documentation](https://python-evdev.readthedocs.io/en/latest/usage.html).)
+
+
+To find the user running octoprint, run:
+
+    sudo ps aux | grep octoprint\\\|USER
+
+To ensure that that user is not currently part of the `input` group, run:
+
+    groups theuserrunningoctoprint
+
+If the user is not part of the `input` group, run:
+
+    sudo usermod -a -G input theuserrunningoctoprint
+
+You will then need to reboot the system to ensure the new group is registered
+for running processes/sessions.


### PR DESCRIPTION
I encountered an devices where no items were showing in the configuration editor, and found that there are a few issues describing such a problem, but none with a solution that helped. I realized it was a permission issue with `evdev` and figured I'd add some information to help the next person.

If this isn't the appropriate place to add it, let me know where it can be placed or feel free to add it to a more appropriate location.