### PR TITLE
Ignore non-USB devices when creating the input options list.

### DIFF
--- a/octoprint_usb_keyboard/usb_keyboard/listener/keyboard_listener_evdev.py
+++ b/octoprint_usb_keyboard/usb_keyboard/listener/keyboard_listener_evdev.py
@@ -66,7 +66,12 @@ class KeyboardListenerThread(threading.Thread):
     devices = [InputDevice(device) for device in list_devices()]
     for device in devices:
       message += f"  Device {device}\n"
-      options.append(str(device)[7:24].replace(",", ""))
       message += f"    Info {device.info}\n"
       message += f"    Physical {device.phys}\n"
+
+      if "usb" not in device.phys:
+          message += f"    Not including in list as not a usb device\n"
+          continue
+
+      options.append(str(device)[7:24].replace(",", ""))
     return message, options


### PR DESCRIPTION
My system gives a dozen options and this narrows it to 2.